### PR TITLE
Resolve #12, allowing the provided classmapping client to be iterable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `tbpixel/xml-streamer` will be documented in this file.
 
+## 1.2.0 - 2019-03-05
+
+- Resolve issue #12, implementing IteratorAggregate onto the client to allow for convenient looping.
+
 ## 1.1.2 - 2019-02-14
 
 - Resolves issue #8, fixing stream size calculation and adjusting tests accordingly.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Say we had an XML file called `users.xml` with the following data:
 </users>
 ```
 
-With this package, we can simply create a new *Client*, pass it a PSR-7 compatible stream, and work with our data using our types.
+With this package, we can simply create a new _Client_, pass it a PSR-7 compatible stream, and work with our data using our types.
 
 ```php
 $stream = new \TBPixel\XMLStreamer\Streams\FileReaderStream('users.xml', 1);
@@ -57,6 +57,15 @@ foreach ($client->iterate() as $simpleXMLElement) {
 }
 
 $client->close(); // Closes the client's provided stream
+```
+
+We can also loop the client directly, as it implements the `IteratorAggregate` interface.
+
+```php
+// Same as above loop
+foreach ($client as $simpleXMLElement) {
+    // Do something with the SimpleXMLElement
+}
 ```
 
 #### Iteration Depth

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,7 @@ namespace TBPixel\XMLStreamer;
 
 use Psr\Http\Message\StreamInterface;
 
-class Client
+class Client implements \IteratorAggregate
 {
     /**
      * The XML Stream.
@@ -48,6 +48,15 @@ class Client
     public function close()
     {
         $this->stream->close();
+    }
+
+    public function getIterator()
+    {
+        foreach ($this->iterate() as $value) {
+            yield $value;
+        }
+
+        $this->stream->rewind();
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare (strict_types = 1);
 
 namespace TBPixel\XMLStreamer\Tests;
 
@@ -32,6 +32,16 @@ final class ClientTest extends TestCase
         $client = new Client($this->stream);
 
         foreach ($client->iterate() as $type) {
+            $this->assertInstanceOf(\SimpleXMLElement::class, $type);
+        }
+    }
+
+    /** @test */
+    public function can_loop_test_data()
+    {
+        $client = new Client($this->stream);
+
+        foreach ($client as $type) {
             $this->assertInstanceOf(\SimpleXMLElement::class, $type);
         }
     }


### PR DESCRIPTION
This small update makes the provided client iterable. It takes advantage of generators for user convenience.