### PR TITLE
Implements mutation testing and resolves #10.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ composer.phar
 
 # PHP Dev cache files
 .php*
+
+# Infection mutation testing
+infection.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `tbpixel/xml-streamer` will be documented in this file.
 
+## 1.3.0 - 2019-03-06
+
+- Implements mutation testing library `infection`.
+- Fixes an issue where the cursor was not wrapping correctly and adds tests.
+- Fixes an issue where the `XMLReader` based streams did not properly rewind.
+- Fixes an issue where `__toString` may throw an exception.
+- Fixes an issue where iterating by tag name only returned the first result.
+
 ## 1.2.0 - 2019-03-05
 
 - Resolve issue #12, implementing IteratorAggregate onto the client to allow for convenient looping.

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,12 @@ optimize:
 test:
 	./vendor/bin/phpunit
 
+test-mutations:
+	./vendor/bin/infection
+
 cs-fixer:
 	./vendor/bin/php-cs-fixer fix ./src
 	./vendor/bin/php-cs-fixer fix ./tests
 
 analyse:
-	./vendor/bin/phpstan analyse --level=max ./src ./tests
+	./vendor/bin/phpstan analyse --level=max ./src

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "phpunit/phpunit": "^8.0",
         "friendsofphp/php-cs-fixer": "^2.14",
         "phpstan/phpstan": "^0.11.1",
-        "symfony/var-dumper": "^4.2"
+        "symfony/var-dumper": "^4.2",
+        "infection/infection": "^0.12.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ab10a4593f11f9efc37cec0cbca3897",
+    "content-hash": "af825d0d591f127949d3fe09b06b43e8",
     "packages": [
         {
             "name": "psr/http-message",
@@ -58,6 +58,62 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
+                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "time": "2019-01-28T09:30:10+00:00"
+        },
         {
             "name": "composer/semver",
             "version": "1.4.2",
@@ -437,6 +493,95 @@
             "time": "2019-01-04T18:29:47+00:00"
         },
         {
+            "name": "infection/infection",
+            "version": "0.12.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/infection/infection.git",
+                "reference": "0c028b4b69bbead4b9d6702b36c0d25b9e016785"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/infection/infection/zipball/0c028b4b69bbead4b9d6702b36c0d25b9e016785",
+                "reference": "0c028b4b69bbead4b9d6702b36c0d25b9e016785",
+                "shasum": ""
+            },
+            "require": {
+                "composer/xdebug-handler": "^1.3",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "justinrainbow/json-schema": "^5.2",
+                "nikic/php-parser": "^4.1",
+                "ocramius/package-versions": "^1.2",
+                "padraic/phar-updater": "^1.0.4",
+                "php": "^7.1.3",
+                "pimple/pimple": "^3.2",
+                "sebastian/diff": "^1.4 || ^2.0 || ^3.0",
+                "symfony/console": "^3.4 || ^4.0",
+                "symfony/filesystem": "^3.4 || ^4.0",
+                "symfony/finder": "^3.4 || ^4.0",
+                "symfony/process": "^3.4|| ^4.0",
+                "symfony/yaml": "^3.4 || ^4.0",
+                "webmozart/assert": "^1.3"
+            },
+            "conflict": {
+                "symfony/console": "=3.4.16 || =4.1.5",
+                "symfony/process": "3.4.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "bin": [
+                "bin/infection"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Infection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Maks Rafalko",
+                    "email": "maks.rafalko@gmail.com",
+                    "homepage": "https://twitter.com/maks_rafalko"
+                },
+                {
+                    "name": "Gert de Pagter",
+                    "homepage": "https://github.com/BackEndTea"
+                },
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com",
+                    "homepage": "https://twitter.com/tfidry"
+                },
+                {
+                    "name": "Oleg Zhulnev",
+                    "homepage": "https://github.com/sidz"
+                },
+                {
+                    "name": "Alexey Kopytko",
+                    "email": "alexey@kopytko.com",
+                    "homepage": "https://www.alexeykopytko.com"
+                }
+            ],
+            "description": "Infection is a Mutation Testing framework for PHP. The mutation adequacy score can be used to measure the effectiveness of a test set in terms of its ability to detect faults.",
+            "keywords": [
+                "coverage",
+                "mutant",
+                "mutation framework",
+                "mutation testing",
+                "testing",
+                "unit testing"
+            ],
+            "time": "2019-02-10T18:24:30+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "1.2",
             "source": {
@@ -486,6 +631,72 @@
                 "versions"
             ],
             "time": "2018-06-13T13:22:40+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/dcb6e1006bb5fd1e392b4daa68932880f37550d4",
+                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.2.20",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "time": "2019-01-14T23:55:14+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1111,6 +1322,127 @@
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
             "time": "2018-02-05T13:05:30+00:00"
+        },
+        {
+            "name": "padraic/humbug_get_contents",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/humbug/file_get_contents.git",
+                "reference": "dcb086060c9dd6b2f51d8f7a895500307110b7a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/humbug/file_get_contents/zipball/dcb086060c9dd6b2f51d8f7a895500307110b7a7",
+                "reference": "dcb086060c9dd6b2f51d8f7a895500307110b7a7",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "ext-openssl": "*",
+                "php": "^5.3 || ^7.0 || ^7.1 || ^7.2"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.1",
+                "mikey179/vfsstream": "^1.6",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": false
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\": "src/"
+                },
+                "files": [
+                    "src/function.php",
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Secure wrapper for accessing HTTPS resources with file_get_contents for PHP 5.3+",
+            "homepage": "https://github.com/padraic/file_get_contents",
+            "keywords": [
+                "download",
+                "file_get_contents",
+                "http",
+                "https",
+                "ssl",
+                "tls"
+            ],
+            "time": "2018-02-12T18:47:17+00:00"
+        },
+        {
+            "name": "padraic/phar-updater",
+            "version": "v1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/humbug/phar-updater.git",
+                "reference": "d01d3b8f26e541ac9b9eeba1e18d005d852f7ff1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/humbug/phar-updater/zipball/d01d3b8f26e541ac9b9eeba1e18d005d852f7ff1",
+                "reference": "d01d3b8f26e541ac9b9eeba1e18d005d852f7ff1",
+                "shasum": ""
+            },
+            "require": {
+                "padraic/humbug_get_contents": "^1.0",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Humbug\\SelfUpdate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                }
+            ],
+            "description": "A thing to make PHAR self-updating easy and secure.",
+            "keywords": [
+                "humbug",
+                "phar",
+                "self-update",
+                "update"
+            ],
+            "time": "2018-03-30T12:52:15+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -1977,6 +2309,105 @@
                 "xunit"
             ],
             "time": "2019-02-03T17:34:56+00:00"
+        },
+        {
+            "name": "pimple/pimple",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/silexphp/Pimple.git",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pimple": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Pimple, a simple Dependency Injection Container",
+            "homepage": "http://pimple.sensiolabs.org",
+            "keywords": [
+                "container",
+                "dependency injection"
+            ],
+            "time": "2018-01-21T07:42:36+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/log",
@@ -3356,6 +3787,65 @@
                 "dump"
             ],
             "time": "2019-01-30T11:44:30+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/761fa560a937fd7686e5274ff89dcfa87a5047df",
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -1,0 +1,14 @@
+{
+    "timeout": 10,
+    "source": {
+        "directories": [
+            "src"
+        ]
+    },
+    "logs": {
+        "text": "infection.log"
+    },
+    "mutators": {
+        "@default": true
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         forceCoversAnnotation="true"
-         beStrictAboutCoversAnnotation="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         colors="true"
-         verbose="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd" bootstrap="vendor/autoload.php" beStrictAboutOutputDuringTests="true" beStrictAboutTodoAnnotatedTests="true" colors="true" verbose="true">
     <testsuites>
         <testsuite name="default">
             <directory suffix="Test.php">tests</directory>

--- a/src/Client.php
+++ b/src/Client.php
@@ -62,7 +62,7 @@ class Client implements \IteratorAggregate
     /**
      * Casts a SimpleXMLElement to a given object by classname, or returns simple xml element if unavailable.
      */
-    protected function cast(\SimpleXMLElement $element): object
+    private function cast(\SimpleXMLElement $element): object
     {
         if (!isset($this->classmap[$element->getName()])) {
             return $element;

--- a/src/Cursor.php
+++ b/src/Cursor.php
@@ -55,13 +55,7 @@ final class Cursor
      */
     public function set(int $position): self
     {
-        if ($position < 0) {
-            $this->position = $this->max + $position;
-        } elseif ($position > $this->max) {
-            $this->position = $this->max - $position;
-        } else {
-            $this->position = $position;
-        }
+        $this->position = max(0, min($position, $this->max));
 
         return $this;
     }
@@ -71,7 +65,17 @@ final class Cursor
      */
     public function move(int $distance): self
     {
-        return $this->set($this->position + $distance);
+        $pos = $this->position + $distance;
+        $range = $this->max + 1;
+
+        if ($pos < 0) {
+            $pos = -$pos % $range;
+            $pos = $this->max - ($pos - 1);
+        } elseif ($pos > $this->max) {
+            $pos = $distance % $range;
+        }
+
+        return $this->set($pos);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,4 +1,4 @@
-<?php declare (strict_types = 1);
+<?php declare(strict_types = 1);
 
 namespace TBPixel\XMLStreamer\Tests;
 
@@ -29,32 +29,80 @@ final class ClientTest extends TestCase
     /** @test */
     public function can_iterate_test_data()
     {
+        $items = [];
         $client = new Client($this->stream);
 
         foreach ($client->iterate() as $type) {
             $this->assertInstanceOf(\SimpleXMLElement::class, $type);
+
+            $items[] = $type;
         }
+
+        $this->assertNotEmpty($items);
+        $this->assertEquals(1, (int)$items[0]->id);
     }
 
     /** @test */
     public function can_loop_test_data()
     {
+        $items = [];
         $client = new Client($this->stream);
 
         foreach ($client as $type) {
             $this->assertInstanceOf(\SimpleXMLElement::class, $type);
+
+            $items[] = $type;
         }
+
+        $this->assertNotEmpty($items);
+        $this->assertEquals(1, (int)$items[0]->id);
     }
 
     /** @test */
     public function can_map_records_to_test_data()
     {
+        $items = [];
         $client = new Client($this->stream, [
             'record' => TestRecord::class,
         ]);
 
         foreach ($client->iterate() as $record) {
             $this->assertInstanceOf(TestRecord::class, $record);
+
+            $items[] = $record;
         }
+
+        $this->assertNotEmpty($items);
+        $this->assertEquals(1, $items[0]->id);
+        $this->assertInstanceOf(TestRecord::class, $items[0]);
+    }
+
+    /** @test */
+    public function classmapped_classes_must_impement_createfromsimplexml()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $client = new Client($this->stream, [
+            'record' => \stdClass::class,
+        ]);
+    }
+
+    /** @test */
+    public function stream_will_rewind_after_iteration()
+    {
+        for ($i = 0; $i < 2; $i++) {
+            $this->can_loop_test_data();
+        }
+    }
+
+    /** @test */
+    public function can_close_stream()
+    {
+        $client = new Client($this->stream);
+        $client->close();
+
+        $this->assertFalse($this->stream->isReadable());
+        $this->assertFalse($this->stream->isSeekable());
+        $this->assertFalse($this->stream->isWritable());
     }
 }

--- a/tests/CursorTest.php
+++ b/tests/CursorTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace TBPixel\XMLStreamer\Tests;
+
+use TBPixel\XMLStreamer\Cursor;
+use PHPUnit\Framework\TestCase;
+
+final class CursorTest extends TestCase
+{
+    /**
+     * @var \TBPixel\XMLStreamer\Cursor
+     */
+    private $cursor;
+
+    /**
+     * @var int
+     */
+    private $max;
+
+    protected function setUp(): void
+    {
+        $this->max = 10;
+        $this->cursor = new Cursor($this->max);
+    }
+
+    /** @test */
+    public function can_get_max_position()
+    {
+        $this->assertEquals($this->max, $this->cursor->max());
+    }
+
+    /** @test */
+    public function can_set_position()
+    {
+        $this->cursor->set(1);
+        $this->assertEquals(1, $this->cursor->position());
+    }
+
+    /** @test */
+    public function cannot_set_beyond_range()
+    {
+        $this->cursor->set(11);
+        $this->assertEquals($this->max, $this->cursor->position());
+
+        $this->cursor->set(-1);
+        $this->assertEquals(0, $this->cursor->position());
+    }
+
+    /** @test */
+    public function can_move_position_relatively()
+    {
+        $this->cursor->move(1);
+        $this->assertEquals(1, $this->cursor->position());
+
+        $this->cursor->move(-1);
+        $this->assertEquals(0, $this->cursor->position());
+    }
+
+    /** @test */
+    public function can_wrap_position()
+    {
+        $this->cursor->move(11);
+        $this->assertEquals(0, $this->cursor->position());
+
+        $this->cursor->move(-1);
+        $this->assertEquals($this->max, $this->cursor->position());
+    }
+
+    /** @test */
+    public function can_move_position_backwards()
+    {
+        $this->cursor->backwards();
+        $this->assertEquals($this->max, $this->cursor->position());
+
+        $this->cursor->reset();
+        $this->cursor->backwards(2);
+        $this->assertEquals(9, $this->cursor->position());
+    }
+
+    /** @test */
+    public function can_move_position_forwards()
+    {
+        $this->cursor->forwards();
+        $this->assertEquals(1, $this->cursor->position());
+
+        $this->cursor->reset();
+        $this->cursor->forwards(11);
+        $this->assertEquals(0, $this->cursor->position());
+    }
+}

--- a/tests/FileReaderStreamTest.php
+++ b/tests/FileReaderStreamTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace TBPixel\XMLStreamer\Tests;
 
@@ -9,5 +9,55 @@ final class FileReaderStreamTest extends ReaderStreamTest
     protected function newStream(): \Psr\Http\Message\StreamInterface
     {
         return new FileReaderStream(__DIR__ . '/assets/test-data.xml', 1);
+    }
+
+    /** @test */
+    public function cannot_open_non_existent_file()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        new FileReaderStream('foobar');
+    }
+
+    /** @test */
+    public function will_return_zero_if_unknown_file_size()
+    {
+        $this->expectException(\RuntimeException::class);
+
+        $stream = new FileReaderStream('foobar');
+
+        $this->assertEquals(0, $stream->getSize());
+    }
+
+    /** @test */
+    public function default_depth_starts_at_root()
+    {
+        $stream = new FileReaderStream(__DIR__ . '/assets/test-data.xml');
+
+        $testDataString = '
+            <testdata>
+                <record>
+                    <id>1</id>
+                    <first_name>Celina</first_name>
+                    <last_name>Elgey</last_name>
+                    <email>celgey0@purevolume.com</email>
+                    <gender>Female</gender>
+                    <ip_address>26.110.129.53</ip_address>
+                </record>
+                <record>
+                    <id>2</id>
+                    <first_name>Theodor</first_name>
+                    <last_name>Blanch</last_name>
+                    <email>tblanch1@bloomberg.com</email>
+                    <gender>Male</gender>
+                    <ip_address>34.246.226.138</ip_address>
+                </record>
+            </testdata>';
+
+
+        $actual = str_replace(["\n", ' '], '', $stream->getContents());
+        $expected = str_replace(["\n", ' '], '', $testDataString);
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/ReaderStreamTest.php
+++ b/tests/ReaderStreamTest.php
@@ -1,8 +1,9 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace TBPixel\XMLStreamer\Tests;
 
 use PHPUnit\Framework\TestCase;
+use TBPixel\XMLStreamer\Streams\ReaderStream;
 
 abstract class ReaderStreamTest extends TestCase
 {
@@ -14,6 +15,11 @@ abstract class ReaderStreamTest extends TestCase
     protected $stream;
 
     /**
+     * @var string
+     */
+    private $testDataString;
+
+    /**
      * Return a new stream implementation for testing.
      */
     abstract protected function newStream(): \Psr\Http\Message\StreamInterface;
@@ -21,6 +27,23 @@ abstract class ReaderStreamTest extends TestCase
     protected function setUp(): void
     {
         $this->stream = $this->newStream();
+        $this->testDataString = '
+            <record>
+                <id>1</id>
+                <first_name>Celina</first_name>
+                <last_name>Elgey</last_name>
+                <email>celgey0@purevolume.com</email>
+                <gender>Female</gender>
+                <ip_address>26.110.129.53</ip_address>
+            </record>
+            <record>
+                <id>2</id>
+                <first_name>Theodor</first_name>
+                <last_name>Blanch</last_name>
+                <email>tblanch1@bloomberg.com</email>
+                <gender>Male</gender>
+                <ip_address>34.246.226.138</ip_address>
+            </record>';
     }
 
     protected function tearDown(): void
@@ -80,15 +103,32 @@ abstract class ReaderStreamTest extends TestCase
     public function can_get_contents()
     {
         $actual = str_replace(["\n", ' '], '', $this->stream->getContents());
-        $expected = file_get_contents(__DIR__ . '/assets/test-data.xml');
 
-        if (!$expected) {
-            throw new \RuntimeException("test data could not be loaded!");
-        }
+        $expected = str_replace(["\n", ' '], '', $this->testDataString);
 
-        $expected = str_replace(["\n", ' '], '', $expected);
+        $this->assertEquals($expected, $actual);
+    }
 
-        $this->assertStringContainsString($actual, $expected);
+    /** @test */
+    public function can_convert_to_string()
+    {
+        $actual = str_replace(["\n", ' '], '', $this->stream->__toString());
+
+        $expected = str_replace(["\n", ' '], '', $this->testDataString);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /** @test */
+    public function must_rewind_before_converting_to_string()
+    {
+        $this->stream->seek(0, SEEK_END);
+
+        $actual = str_replace(["\n", ' '], '', $this->stream->__toString());
+
+        $expected = str_replace(["\n", ' '], '', $this->testDataString);
+
+        $this->assertEquals($expected, $actual);
     }
 
     /** @test */
@@ -102,5 +142,105 @@ abstract class ReaderStreamTest extends TestCase
         $this->assertNotEmpty($meta);
         $this->assertNotNull($size);
         $this->assertNull($fake);
+    }
+
+    /** @test */
+    public function can_close_stream()
+    {
+        $this->stream->close();
+
+        $this->assertFalse($this->stream->isReadable());
+        $this->assertFalse($this->stream->isSeekable());
+        $this->assertFalse($this->stream->isWritable());
+    }
+
+    /** @test */
+    public function cannot_seek_when_closed()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->stream->close();
+        $this->stream->seek(0);
+    }
+
+    /** @test */
+    public function cannot_read_when_closed()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->stream->close();
+        $this->stream->read(0);
+    }
+
+    /** @test */
+    public function cannot_read_when_detatched()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->stream->detach();
+        $this->stream->read(0);
+    }
+
+    /** @test */
+    public function stream_will_close_when_destructured()
+    {
+        $this->stream->__destruct();
+
+        $this->assertFalse($this->stream->isReadable());
+        $this->assertFalse($this->stream->isSeekable());
+        $this->assertFalse($this->stream->isWritable());
+    }
+
+    /** @test */
+    public function can_determine_if_eof()
+    {
+        $this->stream->seek(0, SEEK_END);
+        $this->assertTrue($this->stream->eof());
+
+        $this->stream->seek(-1, SEEK_END);
+        $this->assertFalse($this->stream->eof());
+    }
+
+    /** @test */
+    public function default_depth_starts_at_root()
+    {
+        $stream = new class extends ReaderStream {
+            protected function newXMLReader(): \XMLReader
+            {
+                $reader = new \XMLReader();
+
+                $reader->open(__DIR__ . '/assets/test-data.xml');
+
+                return $reader;
+            }
+
+            protected function sizeInBytes(): int
+            {
+                return 0;
+            }
+        };
+
+        $testDataString = '
+            <testdata>
+                <record>
+                    <id>1</id>
+                    <first_name>Celina</first_name>
+                    <last_name>Elgey</last_name>
+                    <email>celgey0@purevolume.com</email>
+                    <gender>Female</gender>
+                    <ip_address>26.110.129.53</ip_address>
+                </record>
+                <record>
+                    <id>2</id>
+                    <first_name>Theodor</first_name>
+                    <last_name>Blanch</last_name>
+                    <email>tblanch1@bloomberg.com</email>
+                    <gender>Male</gender>
+                    <ip_address>34.246.226.138</ip_address>
+                </record>
+            </testdata>';
+
+
+        $actual = str_replace(["\n", ' '], '', $stream->getContents());
+        $expected = str_replace(["\n", ' '], '', $testDataString);
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/StringReaderStreamTest.php
+++ b/tests/StringReaderStreamTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace TBPixel\XMLStreamer\Tests;
 
@@ -7,6 +7,11 @@ use TBPixel\XMLStreamer\Streams\StringReaderStream;
 
 final class StringReaderStreamTest extends ReaderStreamTest
 {
+    /**
+     * @var string
+     */
+    private $body;
+
     protected function newStream(): \Psr\Http\Message\StreamInterface
     {
         $body = file_get_contents(__DIR__ . '/assets/test-data.xml');
@@ -15,6 +20,40 @@ final class StringReaderStreamTest extends ReaderStreamTest
             throw new \RuntimeException("test data could not be loaded!");
         }
 
-        return new StringReaderStream($body, 'UTF-8', 1);
+        $this->body = $body;
+
+        return new StringReaderStream($this->body, 'UTF-8', 1);
+    }
+
+    /** @test */
+    public function default_depth_starts_at_root()
+    {
+        $stream = new StringReaderStream($this->body);
+
+        $testDataString = '
+            <testdata>
+                <record>
+                    <id>1</id>
+                    <first_name>Celina</first_name>
+                    <last_name>Elgey</last_name>
+                    <email>celgey0@purevolume.com</email>
+                    <gender>Female</gender>
+                    <ip_address>26.110.129.53</ip_address>
+                </record>
+                <record>
+                    <id>2</id>
+                    <first_name>Theodor</first_name>
+                    <last_name>Blanch</last_name>
+                    <email>tblanch1@bloomberg.com</email>
+                    <gender>Male</gender>
+                    <ip_address>34.246.226.138</ip_address>
+                </record>
+            </testdata>';
+
+
+        $actual = str_replace(["\n", ' '], '', $stream->getContents());
+        $expected = str_replace(["\n", ' '], '', $testDataString);
+
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/TagDepthTest.php
+++ b/tests/TagDepthTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace TBPixel\XMLStreamer\Tests;
 
@@ -8,7 +8,7 @@ final class TagDepthTest extends ReaderStreamTest
 {
     protected function newStream(): \Psr\Http\Message\StreamInterface
     {
-        return new FileReaderStream(__DIR__ . '/assets/test-data.xml', 'testdata');
+        return new FileReaderStream(__DIR__ . '/assets/test-data.xml', 'record');
     }
 
     /** @test */
@@ -17,6 +17,7 @@ final class TagDepthTest extends ReaderStreamTest
         $stream = new FileReaderStream(__DIR__ . '/assets/test-data.xml', 'fake-tag');
         $empty = $stream->read(0);
 
+        $this->assertIsString($empty);
         $this->assertEmpty($empty);
     }
 }


### PR DESCRIPTION
This update implements the `infection/infection` mutation testing framework into the code base. Thanks to mutation testing, a number of bugs and untested features now have tests and fixes applied to them. These changes are non-breaking, but due to the size of the mutation testing feature I have implemented it as a minor-version change rather than a patch.

In addition, the Makefile now contains the `test-mutations` command to streamline testing commands.