### PR TITLE
Allows the client to be countable; resolves #16.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to `tbpixel/xml-streamer` will be documented in this file.
 
-## 1.3.0 - 2019-03-06
+## 1.4.0 - 2019-03-11
+
+- Allows the client to be countable, resolving #16.
+
+## 1.3.0 - 2019-03-11
 
 - Implements mutation testing library `infection`.
 - Fixes an issue where the cursor was not wrapping correctly and adds tests.

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,7 +4,7 @@ namespace TBPixel\XMLStreamer;
 
 use Psr\Http\Message\StreamInterface;
 
-class Client implements \IteratorAggregate
+class Client implements \IteratorAggregate, \Countable
 {
     /**
      * The XML Stream.
@@ -57,6 +57,19 @@ class Client implements \IteratorAggregate
         }
 
         $this->stream->rewind();
+    }
+
+    public function count()
+    {
+        $i = 0;
+
+        foreach ($this->iterate() as $v) {
+            $i += 1;
+        }
+
+        $this->stream->rewind();
+
+        return $i;
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -59,6 +59,13 @@ final class ClientTest extends TestCase
     }
 
     /** @test */
+    public function can_count_test_data()
+    {
+        $client = new Client($this->stream);
+        $this->assertCount(2, $client);
+    }
+
+    /** @test */
     public function can_map_records_to_test_data()
     {
         $items = [];


### PR DESCRIPTION
This allows the XML Streamer iterator client to be countable.