### PR TITLE
Allows the client to collect items as an array; resolves #17.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `tbpixel/xml-streamer` will be documented in this file.
 
+## 1.5.0 - 2019-03-11
+
+- Allows the client to return an array of items, resolving #17.
+
 ## 1.4.0 - 2019-03-11
 
 - Allows the client to be countable, resolving #16.

--- a/src/Client.php
+++ b/src/Client.php
@@ -41,6 +41,20 @@ class Client implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Collects all iterable items into an array.
+     */
+    public function collect(): array
+    {
+        $items = [];
+
+        foreach ($this->iterate() as $v) {
+            $items[] = $v;
+        }
+
+        return $items;
+    }
+
+    /**
      * Closes the stream from the client.
      *
      * @return void

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -43,6 +43,16 @@ final class ClientTest extends TestCase
     }
 
     /** @test */
+    public function can_collect_test_data()
+    {
+        $client = new Client($this->stream);
+        $items = $client->collect();
+
+        $this->assertIsArray($items);
+        $this->assertCount(2, $items);
+    }
+
+    /** @test */
     public function can_loop_test_data()
     {
         $items = [];


### PR DESCRIPTION
This update allows the Client to collect and return all iterated items as an array. It can be useful when the implementer needs to work with arrays instead of just iterators.