### PR TITLE
Fixes #21, an issue where ReaderStream did not iterate records correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `tbpixel/xml-streamer` will be documented in this file.
 
+## 1.5.1 - 2019-03-11
+
+- Resolves an issue where ReaderStream did not iterate every record correctly; fixes #21.
+
 ## 1.5.0 - 2019-03-11
 
 - Allows the client to return an array of items, resolving #17.

--- a/src/Streams/ReaderStream.php
+++ b/src/Streams/ReaderStream.php
@@ -293,7 +293,7 @@ abstract class ReaderStream implements StreamInterface
                 }
 
                 // Iterate nodes only
-                if ($this->reader->nodeType !== \XMLReader::ELEMENT) {
+                if ($this->reader->nodeType !== \XMLReader::ELEMENT && $this->reader->nodeType !== \XMLReader::END_ELEMENT) {
                     continue;
                 }
 
@@ -309,7 +309,7 @@ abstract class ReaderStream implements StreamInterface
                 }
 
                 // Skip to content depth
-                if ($this->reader->depth < $depth) {
+                if (is_int($this->depth) && $this->reader->depth < $depth) {
                     continue;
                 }
 

--- a/tests/MemoryUsageTest.php
+++ b/tests/MemoryUsageTest.php
@@ -18,7 +18,7 @@ final class MemoryUsageTest extends TestCase
 
     protected function setUp(): void
     {
-        $stream = new FileReaderStream(__DIR__ . '/assets/3MB-test-data.xml', 1);
+        $stream = new FileReaderStream(__DIR__ . '/assets/3MB-test-data.xml', 'track');
 
         $this->client = new Client($stream, [
             'track' => TestTrack::class,
@@ -36,11 +36,14 @@ final class MemoryUsageTest extends TestCase
         $filesize = filesize(__DIR__ . '/assets/3MB-test-data.xml');
         $maxMemory = memory_get_usage() + $filesize;
         $peak = memory_get_peak_usage();
+        $count = 0;
 
         foreach ($this->client->iterate() as $type) {
             // Allows us to check for totaly memory usage.
+            $count += 1;
         }
 
         $this->assertLessThan($filesize, $maxMemory - $peak);
+        $this->assertEquals(25000, $count);
     }
 }

--- a/tests/NamedFileReaderStreamTest.php
+++ b/tests/NamedFileReaderStreamTest.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+namespace TBPixel\XMLStreamer\Tests;
+
+use TBPixel\XMLStreamer\Streams\FileReaderStream;
+
+final class NamedFileReaderStreamTest extends ReaderStreamTest
+{
+    protected function newStream(): \Psr\Http\Message\StreamInterface
+    {
+        return new FileReaderStream(__DIR__ . '/assets/test-data.xml', 'record');
+    }
+}

--- a/tests/ReaderStreamTest.php
+++ b/tests/ReaderStreamTest.php
@@ -55,11 +55,15 @@ abstract class ReaderStreamTest extends TestCase
     public function can_read()
     {
         $this->assertTrue($this->stream->isReadable());
+        $count = 0;
 
-        $data = $this->stream->read(1024);
+        while (!empty($data = $this->stream->read(0))) {
+            $count += 1;
+            $this->assertIsString($data);
+            $this->assertNotEmpty($data);
+        }
 
-        $this->assertIsString($data);
-        $this->assertNotEmpty($data);
+        $this->assertEquals(2, $count);
     }
 
     /** @test */


### PR DESCRIPTION
This pull adds tests and a fix for a ReaderStream bug that caused it to, under certain circumstances, not detect iteration properly (seemingly as a result of odd XML formatting).